### PR TITLE
Parameterize projectile project directory

### DIFF
--- a/nougat/packages/projectile/discover-projects.org
+++ b/nougat/packages/projectile/discover-projects.org
@@ -1,6 +1,10 @@
 * discover projects
+
+** projectile-project-directory
 #+begin_src emacs-lisp
+  (defvar projectile-project-directory (expand-file-name "~/src"))
+
   (projectile-discover-projects-in-directory
-     (file-name-as-directory (expand-file-name "~/src")))
+     (file-name-as-directory projectile-project-directory))
 #+end_src
 


### PR DESCRIPTION
This adds a variable `projectile-project-directory` so you can customize the discovery path for projects.

Just add a src block setting the variable after your include

```text
#+include: "../nougat/packages/projectile/discover-projects.org"
#+begin_src emacs-lisp
  (setq projectile-project-directory (expand-file-name "~/Projects/")
#+end_src